### PR TITLE
chore(ci): trigger workflow on push to default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+  push:
+    branches: main
+
 env:
   AUTH_TOKEN: TEST_DISCORD_AUTH_TOKEN
 


### PR DESCRIPTION
### What does this PR do?

Trigger CI workflow on push to default branch (eg. main)

**Related issue:** N/A
